### PR TITLE
Distribute Task Workload Across Threads Based on Thread Performance

### DIFF
--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -83,11 +83,11 @@ namespace dp {
 
         /**
          * @brief Enqueue a task into the thread pool that returns a result.
-         * @tparam Function An invocable type.
-         * @tparam ...Args Argument parameter pack
+         * @tparam Function An invokable type.
+         * @tparam Args Argument parameter pack
          * @tparam ReturnType The return type of the Function
          * @param f The callable function
-         * @param ...args The parameters that will be passed (copied) to the function.
+         * @param args The parameters that will be passed (copied) to the function.
          * @return A std::future<ReturnType> that can be used to retrieve the returned value.
          */
         template <typename Function, typename... Args,
@@ -117,10 +117,10 @@ namespace dp {
 
         /**
          * @brief Enqueue a task to be executed in the thread pool that returns void.
-         * @tparam Function An invocable type.
-         * @tparam ...Args Argument parameter pack for Function
+         * @tparam Function An invokable type.
+         * @tparam Args Argument parameter pack for Function
          * @param func The callable to be executed
-         * @param ...args Arguments that wiill be passed to the function.
+         * @param args Arguments that will be passed to the function.
          */
         template <typename Function, typename... Args>
         requires std::invocable<Function, Args...> &&

--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -31,22 +31,24 @@ namespace dp {
             return data_.size();
         }
 
-        [[nodiscard]] T& front() {
-            std::unique_lock lock(mutex_);
-            condition_variable_.wait(lock, [this] { return !data_.empty(); });
-            return data_.front();
-        }
+        // [[nodiscard]] T& front() {
+        //     std::unique_lock lock(mutex_);
+        //     condition_variable_.wait(lock, [this] { return !data_.empty(); });
+        //     return data_.front();
+        // }
+        //
+        // [[nodiscard]] T& back() {
+        //     std::unique_lock lock(mutex_);
+        //     condition_variable_.wait(lock, [this] { return !data_.empty(); });
+        //     return data_.back();
+        // }
 
-        [[nodiscard]] T& back() {
+        [[nodiscard]] T pop() {
             std::unique_lock lock(mutex_);
             condition_variable_.wait(lock, [this] { return !data_.empty(); });
-            return data_.back();
-        }
-
-        void pop() {
-            std::unique_lock lock(mutex_);
-            condition_variable_.wait(lock, [this] { return !data_.empty(); });
+            auto front = data_.front();
             data_.pop_front();
+            return front;
         }
 
       private:

--- a/test/source/thread_pool.cpp
+++ b/test/source/thread_pool.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Basic task return types") {
 
 TEST_CASE("Ensure input params are properly passed") {
     dp::thread_pool pool(4);
-    const auto total_tasks = 30;
+    constexpr auto total_tasks = 30;
     std::vector<std::future<int>> futures;
 
     for (auto i = 0; i < total_tasks; i++) {
@@ -33,13 +33,13 @@ TEST_CASE("Ensure input params are properly passed") {
 
 TEST_CASE("Ensure work completes upon destruction") {
     std::atomic<int> counter;
-    std::vector<std::future<int>> futures;
-    const auto total_tasks = 20;
+    constexpr auto total_tasks = 20;
     {
+        std::vector<std::future<int>> futures;
         dp::thread_pool pool(4);
         for (auto i = 0; i < total_tasks; i++) {
             auto task = [index = i, &counter]() {
-                counter++;
+                ++counter;
                 return index;
             };
             futures.push_back(pool.enqueue(task));

--- a/test/source/thread_safe_queue.cpp
+++ b/test/source/thread_safe_queue.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Check size while waiting for front") {
     int item = 0;
     std::jthread wait_for_item_thread([&item, &queue]() {
         // this will block until an item becomes available
-        item = queue.front();
+        item = queue.pop();
     });
 
     if (queue.empty()) {


### PR DESCRIPTION
## Summary

Switched to using a single task queue for all threads and a `std::condition_variable_any` to wake the threads when there is work available. This serves to better balance work loads and ensures the total work completes as quickly as possible. 

## Fixed

* #4 
* Minor issues in documentation

## Changed

* Removed `front()` and `back()` member functions from `dp::thread_safe_queue`. 
* Use a single task queue for all threads