### PR TITLE
Replace notify_all with notify_one on push new item to pool

### DIFF
--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -18,7 +18,7 @@ namespace dp {
                 std::lock_guard lock(mutex_);
                 data_.push_back(std::forward<T>(value));
             }
-            condition_variable_.notify_all();
+            condition_variable_.notify_one();
         }
 
         bool empty() {


### PR DESCRIPTION
using notify_all instead of notify_one cause all threads which waiting, start & then immediately sleep.
It has perfomance issue.