### PR TITLE
Ensure tasks get executed in thread-pool destructor

### DIFF
--- a/test/source/thread_pool.cpp
+++ b/test/source/thread_pool.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Support params of different types") {
 
 TEST_CASE("Ensure work completes upon destruction") {
     std::atomic<int> counter;
-    constexpr auto total_tasks = 20;
+    constexpr auto total_tasks = 30;
     {
         dp::thread_pool pool(4);
         for (auto i = 0; i < total_tasks; i++) {


### PR DESCRIPTION
## Changed

- Add counter so that threads stay busy while there is work; either in the thread's queue or in other thread's queues.