### PR TITLE
Adding support for using this thread pool with coroutines

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -15,6 +15,12 @@ CPMAddPackage(
     OPTIONS "BENCHMARK_ENABLE_TESTING OFF"
 )
 
+CPMAddPackage(
+    NAME cppcoro
+    GITHUB_REPOSITORY andreasbuhr/cppcoro
+    GIT_TAG 10bbcdbf2be3ad3aa56febcf4c7662d771460a99
+)
+
 if(benchmark_ADDED)
     # patch benchmark target
     set_target_properties(benchmark PROPERTIES CXX_STANDARD 20)
@@ -26,7 +32,7 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 file(GLOB headers CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 
 add_executable(${PROJECT_NAME} ${headers} ${sources})
-target_link_libraries(${PROJECT_NAME} benchmark ThreadPool::ThreadPool)
+target_link_libraries(${PROJECT_NAME} benchmark ThreadPool::ThreadPool cppcoro)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/benchmark/include/utilities.h
+++ b/benchmark/include/utilities.h
@@ -2,10 +2,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cppcoro/task.hpp>
 #include <iterator>
 #include <random>
 #include <span>
 #include <vector>
+
+#include "thread_pool/thread_pool.h"
 
 inline std::size_t index(std::size_t row, std::size_t col, std::size_t width) {
     return row * width + col;
@@ -22,6 +25,12 @@ inline void multiply_array(std::span<int> a, std::span<int> b, std::span<int> re
     }
 }
 
+inline cppcoro::task<> co_multiply_array(std::span<int> a, std::span<int> b, std::span<int> result,
+                                         dp::thread_pool<>& pool) {
+    co_await pool.schedule();
+    multiply_array(a, b, result);
+}
+
 template <typename T>
 using multiplication_pair = std::pair<std::vector<T>, std::vector<T>>;
 
@@ -30,6 +39,7 @@ template <typename T>
     const std::int64_t& array_size, const std::int64_t& number_of_multiplications) {
     static std::uniform_int_distribution<T> distribution(std::numeric_limits<T>::min(),
                                                          std::numeric_limits<T>::max());
+    // yes, predictable values
     static std::default_random_engine generator{};
 
     std::vector<multiplication_pair<T>> computations;

--- a/benchmark/source/thread_pool.cpp
+++ b/benchmark/source/thread_pool.cpp
@@ -1,14 +1,18 @@
 #include <benchmark/benchmark.h>
 #include <thread_pool/thread_pool.h>
 
+#include <cppcoro/sync_wait.hpp>
+#include <cppcoro/when_all.hpp>
+
 #include "utilities.h"
 
-static void BM_array_multiplication(benchmark::State& state) {
+static void BM_array_multiplication_thread_pool(benchmark::State& state) {
     const auto array_size = state.range(0);
     const std::size_t multiplications_to_perform = state.range(1);
 
     // generate the data
-    const auto computations = generate_benchmark_data<int>(array_size, multiplications_to_perform);
+    const auto computations = generate_benchmark_data<int>(array_size,
+    multiplications_to_perform);
 
     // task that is run on a new thread
     auto thread_task = [](multiplication_pair<int> pair) {
@@ -28,7 +32,7 @@ static void BM_array_multiplication(benchmark::State& state) {
     }
 }
 
-BENCHMARK(BM_array_multiplication)
+BENCHMARK(BM_array_multiplication_thread_pool)
     ->Args({8, 25'000})
     ->Args({64, 5'000})
     ->Args({256, 250})
@@ -39,3 +43,34 @@ BENCHMARK(BM_array_multiplication)
     ->MeasureProcessCPUTime()
     ->UseRealTime()
     ->Name("dp::thread_pool array mult");
+
+inline cppcoro::task<> mult_task(multiplication_pair<int> pair, dp::thread_pool<>& pool) {
+    std::vector<int> result(pair.first.size());
+    co_await co_multiply_array(pair.first, pair.second, result, pool);
+}
+
+static void BM_array_multiplication_thread_pool_coroutine(benchmark::State& state) {
+    const auto array_size = state.range(0);
+    const std::size_t multiplications_to_perform = state.range(1);
+    const auto computations = generate_benchmark_data<int>(array_size, multiplications_to_perform);
+    dp::thread_pool pool{};
+    std::vector<cppcoro::task<>> tasks;
+    for (auto _ : state) {
+        for (auto mult_pair : computations) {
+            tasks.emplace_back(mult_task(mult_pair, pool));
+        }
+    }
+    cppcoro::sync_wait(cppcoro::when_all(std::move(tasks)));
+}
+
+BENCHMARK(BM_array_multiplication_thread_pool_coroutine)
+    ->Args({8, 25'000})
+    ->Args({64, 5'000})
+    ->Args({256, 250})
+    ->Args({512, 75})
+    ->Args({1024, 10})
+    ->Unit(benchmark::kMillisecond)
+    ->ReportAggregatesOnly(true)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime()
+    ->Name("dp::thread_pool coroutine array mult");

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,4 +1,4 @@
-set(CPM_DOWNLOAD_VERSION 0.32.0)
+set(CPM_DOWNLOAD_VERSION 0.35.5)
 
 if(CPM_SOURCE_CACHE)
     # Expand relative path. This is important if the provided path contains a tilde (~)

--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <concepts>
+#include <coroutine>
 #include <deque>
 #include <functional>
 #include <future>
@@ -163,6 +164,26 @@ namespace dp {
                     } catch (...) {
                     }
                 }));
+        }
+
+        /**
+         * @brief Allows you to schedule coroutines to run on the thread pool. 
+         */
+        auto schedule() {
+            /// @brief Simple awaitable type that we can return.
+            struct scheduled_operation {
+                dp::thread_pool<> *thread_pool_;
+                bool await_ready() { return false; };
+                void await_suspend(std::coroutine_handle<> handle) {
+                    if (thread_pool_) {
+                        thread_pool_->enqueue_detach([](std::coroutine_handle<> h) { h.resume(); },
+                                                     handle);
+                    }
+                }
+                void await_resume() {}
+            };
+
+            return scheduled_operation{this};
         }
 
       private:


### PR DESCRIPTION
## Changed
* Updated `CPM.cmake` version
* Added `schedule()` function to allow for running coroutines on the thread pool
* Added batch `enqueue()` function to better compare to coroutine performance