### PR TITLE
use feature test macro to check feature available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .vs
 out
 CMakeFiles
+.idea
+cmake-build*

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ See the `./benchmark` folder for the benchmark code. The benchmarks are set up t
 Matrix sizes are all square (MxM). Each multiplication is `(MxM) * (MxM)` where `*` refers to a matrix multiplication operation. Times recorded were the best of at least 3 runs.
 
 | Matrix Size | Number of multiplications | `std::async` time (ms) | `dp::thread_pool` time (ms) |
-|:---:|:---:|:---:|:---:|
-| 8 | 25,000 | 77.9 | 65.3 |
-| 64 | 5,000 | 100 | 65.2 |
-| 256 | 250 | 295 | 59.2 |
-| 512 | 75 | 713 | 60.4 |
-| 1024 | 10 | 1160 | 55.8 |
+|:-----------:|:-------------------------:|:----------------------:|:---------------------------:|
+|      8      |          25,000           |          77.9          |            65.3             |
+|     64      |           5,000           |          100           |            65.2             |
+|     256     |            250            |          295           |            59.2             |
+|     512     |            75             |          713           |            60.4             |
+|    1024     |            10             |          1160          |            55.8             |
 
 ## Building
 
@@ -107,10 +107,10 @@ cmake --build build
 
 ### Build Options
 
-| Option | Description | Default |
-|:-------|:------------|:--------:|
-| `TP_BUILD_TESTS` | Turn on to build unit tests. Required for formatting build targets. | ON |
-| `TP_BUILD_EXAMPLES` | Turn on to build examples | ON |
+| Option              | Description                                                         | Default |
+|:--------------------|:--------------------------------------------------------------------|:-------:|
+| `TP_BUILD_TESTS`    | Turn on to build unit tests. Required for formatting build targets. |   ON    |
+| `TP_BUILD_EXAMPLES` | Turn on to build examples                                           |   ON    |
 
 ### Run clang-format
 


### PR DESCRIPTION
# Reason 

thread-pool is a great modern and tiny thread pool. However, using the compiler version to check move_only_function is not solid. For example:

I used g++-12 (Ubuntu 12.1.0-2ubuntu1~22.04) 12.1.0. The library could not compile due to:

error: ‘move_only_function’ in namespace ‘std’ does not name a template type
25 | using default_function_type = std::move_only_function<void()>;
| ^~~~~~~~~~~~~~~~~~

Here is the [ci](https://github.com/ylab-hi/BINARY/actions/runs/3166937007/jobs/5157035925) for detailed information.

Hence, I tried to use [feature testing](https://en.cppreference.com/w/cpp/feature_test) instead and it works well.

I am sure that I may have missed something. :)

