### PR TITLE
Build tests with fsanitize address on

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -13,9 +13,9 @@ jobs:
     name: Build and publish documentation
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,7 +25,8 @@ jobs:
 
       - name: Install format dependencies
         run: |
-          choco install llvm ninja -y
+          choco install llvm --version 15.0.1 -y
+          choco install ninja -y
           pip3 install cmake_format==0.6.11 pyyaml
 
       - name: configure

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: windows-2019
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,9 +23,9 @@ jobs:
       CPP_STANDARD: 20
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: "**/cpm_modules"
           key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
 
 # being a cross-platform target, we enforce standards conformance on MSVC
-target_compile_options(${PROJECT_NAME} INTERFACE "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->")
+target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->)
 
 target_include_directories(
     ${PROJECT_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,45 @@ project(
     LANGUAGES CXX
 )
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+message(STATUS "Compiler version: ${CMAKE_CXX_COMPILER_VERSION}")
+
+# Option to override which C++ standard to use
+set(TP_CXX_STANDARD
+    DETECT
+    CACHE STRING "Override the default CXX_STANDARD to compile with."
+)
+set_property(CACHE TP_CXX_STANDARD PROPERTY STRINGS DETECT 20 23)
+
+# Decide on the standard to use
+if(TP_CXX_STANDARD STREQUAL "20")
+    if("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        message(STATUS "Using C++20 standard")
+        set(CMAKE_CXX_STANDARD 20)
+    else()
+        message(
+            FATAL_ERROR "Requested TP_CXX_STANDARD \"20\" not supported by provided C++ compiler"
+        )
+    endif()
+elseif(TP_CXX_STANDARD STREQUAL "23")
+    if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        message(STATUS "Using C++23 standard")
+        set(CMAKE_CXX_STANDARD 23)
+    else()
+        message(
+            FATAL_ERROR "Requested TP_CXX_STANDARD \"23\" not supported by provided C++ compiler"
+        )
+    endif()
+else()
+    if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 23)
+        message(STATUS "Detected support for C++23 standard")
+    elseif("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+        set(CMAKE_CXX_STANDARD 20)
+        message(STATUS "Detected support for C++20 standard")
+    else()
+        message(FATAL_ERROR "Cannot detect CXX_STANDARD of C++20 or newer.")
+    endif()
+endif()
 
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
     message(
@@ -21,42 +58,27 @@ endif()
 
 # ---- Add dependencies via CPM ----
 # see https://github.com/TheLartians/CPM.cmake for more info
-
 include(cmake/CPM.cmake)
 
 # PackageProject.cmake will be used to make our target installable
 CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.6.0")
 
 # ---- Add source files ----
-
-# Note: globbing sources is considered bad practice as CMake's generators may not detect new files
-# automatically. Keep that in mind when changing files, or explicitly mention them here.
 file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
 
 find_package(Threads REQUIRED)
 
 # ---- Create library ----
-
 add_library(${PROJECT_NAME} INTERFACE)
 add_library(dp::thread-pool ALIAS ${PROJECT_NAME})
 
-message(STATUS "Compiler version: ${CMAKE_CXX_COMPILER_VERSION}")
+target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
 
-if((MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.32)
-   OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12
-      )
-)
-    option(TP_EXPERIMENTAL "Turn on experimental C++23 feature support" ON)
-endif()
-
-if(DEFINED TP_EXPERIMENTAL AND TP_EXPERIMENTAL)
-    message(STATUS "Using experimental C++23 features.")
+if(CMAKE_CXX_STANDARD GREATER 20)
     target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_23)
 else()
     target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_20)
 endif()
-
-target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
 
 # being a cross-platform target, we enforce standards conformance on MSVC
 target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->)

--- a/examples/mandelbrot/include/fractal.h
+++ b/examples/mandelbrot/include/fractal.h
@@ -19,7 +19,7 @@ struct rgb {
 
 /// @brief Simple range class for viewing window and fractal window
 template <class T>
-requires std::integral<T> || std::floating_point<T>
+    requires std::integral<T> || std::floating_point<T>
 struct fractal_window {
     T x_min{};
     T x_max{};

--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -24,8 +24,8 @@ namespace dp {
     }  // namespace details
 
     template <typename FunctionType = details::default_function_type>
-    requires std::invocable<FunctionType> &&
-        std::is_same_v<void, std::invoke_result_t<FunctionType>>
+        requires std::invocable<FunctionType> &&
+                 std::is_same_v<void, std::invoke_result_t<FunctionType>>
     class thread_pool {
       public:
         explicit thread_pool(
@@ -93,7 +93,7 @@ namespace dp {
          */
         template <typename Function, typename... Args,
                   typename ReturnType = std::invoke_result_t<Function &&, Args &&...>>
-        requires std::invocable<Function, Args...>
+            requires std::invocable<Function, Args...>
         [[nodiscard]] std::future<ReturnType> enqueue(Function f, Args... args) {
 #if __cpp_lib_move_only_function
             // we can do this in C++23 because we now have support for move only functions
@@ -146,8 +146,8 @@ namespace dp {
          * @param args Arguments that will be passed to the function.
          */
         template <typename Function, typename... Args>
-        requires std::invocable<Function, Args...> &&
-            std::is_same_v<void, std::invoke_result_t<Function &&, Args &&...>>
+            requires std::invocable<Function, Args...> &&
+                     std::is_same_v<void, std::invoke_result_t<Function &&, Args &&...>>
         void enqueue_detach(Function &&func, Args &&...args) {
             enqueue_task(
                 std::move([f = std::forward<Function>(func),

--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -14,13 +14,13 @@ namespace dp {
      */
     template <typename Lock>
     concept is_lockable = requires(Lock&& lock) {
-        lock.lock();
-        lock.unlock();
-        { lock.try_lock() } -> std::convertible_to<bool>;
-    };
+                              lock.lock();
+                              lock.unlock();
+                              { lock.try_lock() } -> std::convertible_to<bool>;
+                          };
 
     template <typename T, typename Lock = std::mutex>
-    requires is_lockable<Lock>
+        requires is_lockable<Lock>
     class thread_safe_queue {
       public:
         using value_type = T;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,14 +27,23 @@ add_executable(${PROJECT_NAME} ${sources})
 target_link_libraries(${PROJECT_NAME} doctest::doctest ThreadPool::ThreadPool)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 
-target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/fsanitize=address>)
-target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-fsanitize=address>)
+target_compile_options(
+    ${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/fsanitize=address>
+)
+target_compile_options(
+    ${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-fsanitize=address>
+)
 
 # enable compiler warnings
 if(NOT TEST_INSTALLED_VERSION)
-    target_compile_options(ThreadPool INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Wall -Wpedantic -Wextra -Werror>)
+    target_compile_options(
+        ThreadPool INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Wall -Wpedantic -Wextra
+                             -Werror>
+    )
     target_compile_options(ThreadPool INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4 /WX>)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:DOCTEST_CONFIG_USE_STD_HEADERS>)
+    target_compile_definitions(
+        ${PROJECT_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:DOCTEST_CONFIG_USE_STD_HEADERS>
+    )
 endif()
 
 # Note: doctest and similar testing frameworks can automatically configure CMake tests. For other

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(${PROJECT_NAME} doctest::doctest ThreadPool::ThreadPool)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 
 target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/fsanitize=address>)
+target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-fsanitize=address>)
 
 # enable compiler warnings
 if(NOT TEST_INSTALLED_VERSION)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(${PROJECT_NAME} ${sources})
 target_link_libraries(${PROJECT_NAME} doctest::doctest ThreadPool::ThreadPool)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 
+target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/fsanitize=address>)
+
 # enable compiler warnings
 if(NOT TEST_INSTALLED_VERSION)
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,12 +32,9 @@ target_compile_options(${PROJECT_NAME} INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Cla
 
 # enable compiler warnings
 if(NOT TEST_INSTALLED_VERSION)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        target_compile_options(ThreadPool INTERFACE -Wall -Wpedantic -Wextra -Werror)
-    elseif(MSVC)
-        target_compile_options(ThreadPool INTERFACE /W4 /WX)
-        target_compile_definitions(${PROJECT_NAME} PUBLIC DOCTEST_CONFIG_USE_STD_HEADERS)
-    endif()
+    target_compile_options(ThreadPool INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Wall -Wpedantic -Wextra -Werror>)
+    target_compile_options(ThreadPool INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/W4 /WX>)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC $<$<COMPILE_LANG_AND_ID:CXX,MSVC>:DOCTEST_CONFIG_USE_STD_HEADERS>)
 endif()
 
 # Note: doctest and similar testing frameworks can automatically configure CMake tests. For other

--- a/test/source/thread_pool.cpp
+++ b/test/source/thread_pool.cpp
@@ -24,6 +24,15 @@ TEST_CASE("Multiply with functor") {
     CHECK_EQ(result.get(), 12);
 }
 
+TEST_CASE("Pass reference to pool") {
+    int x = 2;
+    {
+        dp::thread_pool pool;
+        pool.enqueue_detach([](int& a) { a *= 2; }, std::ref(x));
+    }
+    CHECK_EQ(x, 4);
+}
+
 TEST_CASE("Pass raw reference to pool") {
     int x = 2;
     {

--- a/test/source/thread_safe_queue.cpp
+++ b/test/source/thread_safe_queue.cpp
@@ -20,9 +20,9 @@ TEST_CASE("Ensure insert and pop works with thread contention") {
     auto res5 = fut5.get();
     auto res6 = fut6.get();
 
-    CHECK(res4.has_value());
-    CHECK(res5.has_value());
-    CHECK(res6.has_value());
+    REQUIRE(res4.has_value());
+    REQUIRE(res5.has_value());
+    REQUIRE(res6.has_value());
 
     // we don't know what order that the values were pushed into the queue
     CHECK_NE(res4.value(), res5.value());


### PR DESCRIPTION
## Changes

* Tests are now build with address sanitizer support on all supported platforms
* New test case for passing a variable reference as a function parameter to the thread pool using `std::ref()`
* Simplify CMake set up and automatically detect maximum C++ standard available to the compiler.

Fixes #17 