### PR TITLE
Upgrade BS::thread-pool to version 3.4.0

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -19,7 +19,7 @@ CPMAddPackage("gh:doctest/doctest@2.4.11")
 CPMAddPackage(
     NAME bshoshany
     GITHUB_REPOSITORY bshoshany/thread-pool
-    VERSION 3.3.0
+    VERSION 3.4.0
     GIT_SHALLOW
 )
 


### PR DESCRIPTION
Upgrade BS::thread-pool to the latest version 3.4.0.

The primary improvement is a major deadlock fix. This deadlock would occasionally cause the benchmarks to freeze.