### PR TITLE
Add task_thread_pool to benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -37,9 +37,9 @@ CPMAddPackage(
 )
 
 CPMAddPackage(
-        NAME task_thread_pool
-        GITHUB_REPOSITORY alugowski/task_thread_pool
-        VERSION 1.0.4
+        NAME task-thread-pool
+        GITHUB_REPOSITORY alugowski/task-thread-pool
+        VERSION 1.0.6
         GIT_SHALLOW
 )
 
@@ -48,7 +48,7 @@ file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 file(GLOB headers CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 
 add_executable(${PROJECT_NAME} ${headers} ${sources})
-target_link_libraries(${PROJECT_NAME} nanobench doctest::doctest bshoshany RiftenThiefpool dp::thread-pool task_thread_pool::task_thread_pool)
+target_link_libraries(${PROJECT_NAME} nanobench doctest::doctest bshoshany RiftenThiefpool dp::thread-pool task-thread-pool::task-thread-pool)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -36,12 +36,19 @@ CPMAddPackage(
     GIT_SHALLOW
 )
 
+CPMAddPackage(
+        NAME task_thread_pool
+        GITHUB_REPOSITORY alugowski/task_thread_pool
+        VERSION 1.0.4
+        GIT_SHALLOW
+)
+
 # ---- Create binary ----
 file(GLOB sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp)
 file(GLOB headers CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h)
 
 add_executable(${PROJECT_NAME} ${headers} ${sources})
-target_link_libraries(${PROJECT_NAME} nanobench doctest::doctest bshoshany RiftenThiefpool dp::thread-pool)
+target_link_libraries(${PROJECT_NAME} nanobench doctest::doctest bshoshany RiftenThiefpool dp::thread-pool task_thread_pool::task_thread_pool)
 set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 20)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 

--- a/benchmark/results/benchmark_results_clang.md
+++ b/benchmark/results/benchmark_results_clang.md
@@ -1,40 +1,45 @@
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 8x8
 |---------:|--------------------:|--------------------:|--------:|----------:|:--------------------------
-|   100.0% |              174.67 |                5.73 |    2.8% |     30.98 | `dp::thread_pool - std::function`
-|   103.4% |              168.90 |                5.92 |    1.4% |     30.16 | `dp::thread_pool - std::move_only_function`
-|    98.3% |              177.71 |                5.63 |    1.2% |     31.77 | `dp::thread_pool - fu2::unique_function`
-|    88.9% |              196.41 |                5.09 |    0.2% |     35.12 | `BS::thread_pool`
-|    99.0% |              176.50 |                5.67 |    1.1% |     31.57 | `riften::Thiefpool`
+|   100.0% |              166.43 |                6.01 |    0.2% |     29.75 | `dp::thread_pool - std::function`
+|   102.8% |              161.86 |                6.18 |    0.6% |     28.98 | `dp::thread_pool - std::move_only_function`
+|   100.1% |              166.31 |                6.01 |    0.4% |     29.74 | `dp::thread_pool - fu2::unique_function`
+|    87.6% |              189.90 |                5.27 |    0.3% |     33.99 | `BS::thread_pool`
+|   107.5% |              154.85 |                6.46 |    0.7% |     27.62 | `task_thread_pool`
+|    89.6% |              185.73 |                5.38 |    1.9% |     33.74 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 64x64
 |---------:|--------------------:|--------------------:|--------:|----------:|:----------------------------
-|   100.0% |              129.37 |                7.73 |    0.5% |     23.27 | `dp::thread_pool - std::function`
-|   102.2% |              126.59 |                7.90 |    0.4% |     22.70 | `dp::thread_pool - std::move_only_function`
-|    98.5% |              131.36 |                7.61 |    0.7% |     23.58 | `dp::thread_pool - fu2::unique_function`
-|    86.5% |              149.61 |                6.68 |    0.8% |     26.80 | `BS::thread_pool`
-|    90.1% |              143.59 |                6.96 |    1.7% |     25.56 | `riften::Thiefpool`
+|   100.0% |              128.74 |                7.77 |    0.1% |     23.08 | `dp::thread_pool - std::function`
+|   102.6% |              125.52 |                7.97 |    0.3% |     22.48 | `dp::thread_pool - std::move_only_function`
+|   100.3% |              128.37 |                7.79 |    0.3% |     22.98 | `dp::thread_pool - fu2::unique_function`
+|    80.5% |              159.85 |                6.26 |    0.8% |     28.59 | `BS::thread_pool`
+|    96.5% |              133.37 |                7.50 |    0.9% |     23.90 | `task_thread_pool`
+|    94.4% |              136.32 |                7.34 |    0.9% |     24.47 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 256x256
 |---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
-|   100.0% |               94.01 |               10.64 |    1.2% |     16.80 | `dp::thread_pool - std::function`
-|   100.1% |               93.91 |               10.65 |    1.4% |     16.94 | `dp::thread_pool - std::move_only_function`
-|    97.9% |               96.01 |               10.42 |    0.4% |     17.18 | `dp::thread_pool - fu2::unique_function`
-|    88.4% |              106.31 |                9.41 |    0.4% |     19.00 | `BS::thread_pool`
-|    98.3% |               95.66 |               10.45 |    1.0% |     17.18 | `riften::Thiefpool`
+|   100.0% |               91.76 |               10.90 |    0.3% |     16.45 | `dp::thread_pool - std::function`
+|   103.1% |               88.99 |               11.24 |    0.5% |     15.92 | `dp::thread_pool - std::move_only_function`
+|   100.2% |               91.58 |               10.92 |    0.2% |     16.40 | `dp::thread_pool - fu2::unique_function`
+|    87.6% |              104.81 |                9.54 |    0.3% |     18.82 | `BS::thread_pool`
+|   104.4% |               87.92 |               11.37 |    0.4% |     15.75 | `task_thread_pool`
+|    99.9% |               91.85 |               10.89 |    0.3% |     16.43 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 512x512
 |---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
-|   100.0% |               72.31 |               13.83 |    1.5% |     13.01 | `dp::thread_pool - std::function`
-|   105.0% |               68.89 |               14.51 |    1.4% |     12.36 | `dp::thread_pool - std::move_only_function`
-|   101.1% |               71.54 |               13.98 |    1.2% |     12.86 | `dp::thread_pool - fu2::unique_function`
-|    90.5% |               79.91 |               12.51 |    0.7% |     14.32 | `BS::thread_pool`
-|    97.5% |               74.17 |               13.48 |    2.9% |     13.48 | `riften::Thiefpool`
+|   100.0% |               68.26 |               14.65 |    0.5% |     12.23 | `dp::thread_pool - std::function`
+|   102.7% |               66.49 |               15.04 |    0.5% |     11.90 | `dp::thread_pool - std::move_only_function`
+|   100.1% |               68.21 |               14.66 |    0.8% |     12.14 | `dp::thread_pool - fu2::unique_function`
+|    90.8% |               75.21 |               13.30 |    0.6% |     13.48 | `BS::thread_pool`
+|    97.9% |               69.70 |               14.35 |    0.2% |     12.45 | `task_thread_pool`
+|   100.8% |               67.69 |               14.77 |    0.6% |     12.07 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 1024x1024
 |---------:|--------------------:|--------------------:|--------:|----------:|:--------------------------------
-|   100.0% |               53.11 |               18.83 |    4.6% |      9.17 | `dp::thread_pool - std::function`
-|   105.4% |               50.37 |               19.85 |    5.7% |      8.43 | :wavy_dash: `dp::thread_pool - std::move_only_function` (Unstable with ~16.3 iters. Increase `minEpochIterations` to e.g. 163)
-|    99.3% |               53.50 |               18.69 |    3.6% |      8.97 | `dp::thread_pool - fu2::unique_function`
-|    82.0% |               64.78 |               15.44 |    0.6% |     11.51 | `BS::thread_pool`
-|    93.0% |               57.11 |               17.51 |    2.1% |      9.59 | `riften::Thiefpool`
+|   100.0% |               53.61 |               18.65 |    2.0% |      9.50 | `dp::thread_pool - std::function`
+|   105.1% |               50.99 |               19.61 |    3.8% |      8.68 | `dp::thread_pool - std::move_only_function`
+|    99.2% |               54.05 |               18.50 |    1.5% |      9.58 | `dp::thread_pool - fu2::unique_function`
+|    86.9% |               61.67 |               16.22 |    0.6% |     11.02 | `BS::thread_pool`
+|    98.7% |               54.34 |               18.40 |    1.2% |      9.75 | `task_thread_pool`
+|   102.0% |               52.54 |               19.03 |    1.2% |      9.25 | `riften::Thiefpool`

--- a/benchmark/results/benchmark_results_msvc.md
+++ b/benchmark/results/benchmark_results_msvc.md
@@ -1,40 +1,45 @@
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 8x8
 |---------:|--------------------:|--------------------:|--------:|----------:|:--------------------------
-|   100.0% |              172.25 |                5.81 |    1.0% |     31.20 | `dp::thread_pool - std::function`
-|   102.7% |              167.79 |                5.96 |    0.7% |     30.55 | `dp::thread_pool - std::move_only_function`
-|    93.5% |              184.15 |                5.43 |    1.2% |     32.97 | `dp::thread_pool - fu2::unique_function`
-|    89.3% |              192.93 |                5.18 |    0.2% |     34.54 | `BS::thread_pool`
-|    91.2% |              188.90 |                5.29 |    4.0% |     34.18 | `riften::Thiefpool`
+|   100.0% |              170.10 |                5.88 |    0.9% |     30.73 | `dp::thread_pool - std::function`
+|   103.0% |              165.14 |                6.06 |    0.7% |     29.57 | `dp::thread_pool - std::move_only_function`
+|    99.3% |              171.27 |                5.84 |    0.4% |     30.69 | `dp::thread_pool - fu2::unique_function`
+|    88.4% |              192.44 |                5.20 |    0.2% |     34.46 | `BS::thread_pool`
+|   109.6% |              155.26 |                6.44 |    0.3% |     27.79 | `task_thread_pool`
+|    95.3% |              178.52 |                5.60 |    0.4% |     31.94 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 64x64
 |---------:|--------------------:|--------------------:|--------:|----------:|:----------------------------
-|   100.0% |              133.91 |                7.47 |    1.0% |     24.28 | `dp::thread_pool - std::function`
-|   102.6% |              130.52 |                7.66 |    0.9% |     23.34 | `dp::thread_pool - std::move_only_function`
-|    98.7% |              135.72 |                7.37 |    0.8% |     24.43 | `dp::thread_pool - fu2::unique_function`
-|    90.0% |              148.80 |                6.72 |    0.7% |     26.80 | `BS::thread_pool`
-|    95.7% |              139.92 |                7.15 |    0.6% |     25.69 | `riften::Thiefpool`
+|   100.0% |              129.75 |                7.71 |    0.4% |     23.23 | `dp::thread_pool - std::function`
+|   101.8% |              127.50 |                7.84 |    0.3% |     22.86 | `dp::thread_pool - std::move_only_function`
+|    97.8% |              132.61 |                7.54 |    0.1% |     23.70 | `dp::thread_pool - fu2::unique_function`
+|    85.4% |              151.98 |                6.58 |    0.6% |     27.26 | `BS::thread_pool`
+|   100.9% |              128.65 |                7.77 |    0.5% |     23.07 | `task_thread_pool`
+|    92.8% |              139.83 |                7.15 |    0.6% |     25.07 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 256x256
 |---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
-|   100.0% |               94.98 |               10.53 |    1.3% |     17.15 | `dp::thread_pool - std::function`
-|   102.8% |               92.43 |               10.82 |    0.8% |     16.44 | `dp::thread_pool - std::move_only_function`
-|    99.0% |               95.98 |               10.42 |    0.8% |     17.27 | `dp::thread_pool - fu2::unique_function`
-|    89.8% |              105.77 |                9.45 |    0.3% |     18.94 | `BS::thread_pool`
-|    96.8% |               98.07 |               10.20 |    0.5% |     17.59 | `riften::Thiefpool`
+|   100.0% |               93.47 |               10.70 |    0.5% |     16.73 | `dp::thread_pool - std::function`
+|   102.6% |               91.06 |               10.98 |    0.6% |     16.26 | `dp::thread_pool - std::move_only_function`
+|    99.3% |               94.17 |               10.62 |    0.4% |     17.03 | `dp::thread_pool - fu2::unique_function`
+|    89.6% |              104.35 |                9.58 |    0.2% |     18.67 | `BS::thread_pool`
+|   100.7% |               92.82 |               10.77 |    0.2% |     16.63 | `task_thread_pool`
+|    96.1% |               97.26 |               10.28 |    0.4% |     17.42 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 512x512
 |---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
-|   100.0% |               28.10 |               35.59 |    1.0% |      5.06 | `dp::thread_pool - std::function`
-|    99.0% |               28.37 |               35.24 |    3.2% |      5.30 | `dp::thread_pool - std::move_only_function`
-|    97.9% |               28.70 |               34.85 |    2.8% |      5.26 | `dp::thread_pool - fu2::unique_function`
-|    35.5% |               79.08 |               12.65 |    1.1% |     14.24 | `BS::thread_pool`
-|    95.1% |               29.54 |               33.85 |    1.1% |      5.32 | `riften::Thiefpool`
+|   100.0% |               27.65 |               36.17 |    1.8% |      4.97 | `dp::thread_pool - std::function`
+|   102.7% |               26.91 |               37.16 |    2.8% |      4.86 | `dp::thread_pool - std::move_only_function`
+|    99.8% |               27.70 |               36.10 |    2.4% |      4.94 | `dp::thread_pool - fu2::unique_function`
+|    34.8% |               79.40 |               12.59 |    0.5% |     14.22 | `BS::thread_pool`
+|    50.4% |               54.83 |               18.24 |    0.8% |      9.85 | `task_thread_pool`
+|   101.0% |               27.37 |               36.54 |    0.7% |      4.91 | `riften::Thiefpool`
 
 | relative |               ms/op |                op/s |    err% |     total | matrix multiplication 1024x1024
 |---------:|--------------------:|--------------------:|--------:|----------:|:--------------------------------
-|   100.0% |               56.71 |               17.63 |    2.3% |     10.60 | `dp::thread_pool - std::function`
-|    99.9% |               56.76 |               17.62 |    1.3% |     10.08 | `dp::thread_pool - std::move_only_function`
-|    99.7% |               56.87 |               17.58 |    4.2% |     10.39 | `dp::thread_pool - fu2::unique_function`
-|    80.2% |               70.71 |               14.14 |    1.1% |     12.93 | `BS::thread_pool`
-|   103.0% |               55.04 |               18.17 |    2.2% |     10.12 | `riften::Thiefpool`
+|   100.0% |               51.97 |               19.24 |    2.1% |      9.16 | `dp::thread_pool - std::function`
+|    99.8% |               52.05 |               19.21 |    2.2% |      9.29 | `dp::thread_pool - std::move_only_function`
+|    98.8% |               52.61 |               19.01 |    0.9% |      9.42 | `dp::thread_pool - fu2::unique_function`
+|    77.7% |               66.88 |               14.95 |    0.5% |     12.01 | `BS::thread_pool`
+|    73.8% |               70.38 |               14.21 |    0.3% |     12.60 | `task_thread_pool`
+|    97.0% |               53.58 |               18.66 |    1.6% |      9.47 | `riften::Thiefpool`

--- a/benchmark/source/matrix_multiplication.cpp
+++ b/benchmark/source/matrix_multiplication.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <future>
 #include <riften/thiefpool.hpp>
+#include <task_thread_pool.hpp>
 
 #include "utilities.h"
 
@@ -109,6 +110,14 @@ TEST_CASE("matrix_multiplication") {
             run_benchmark<int>(&bench, array_size, iterations, "BS::thread_pool",
                                [&](const std::vector<int>& a, const std::vector<int>& b) -> void {
                                    bs_thread_pool.push_task(thread_task, a, b);
+                               });
+        }
+
+        {
+            task_thread_pool::task_thread_pool ttp{};
+            run_benchmark<int>(&bench, array_size, iterations, "task_thread_pool",
+                               [&](const std::vector<int>& a, const std::vector<int>& b) -> void {
+                                   ttp.submit_detach(thread_task, a, b);
                                });
         }
 


### PR DESCRIPTION
Add https://github.com/alugowski/task_thread_pool to the benchmarks.

`task_thread_pool` is a C++11 thread pool. It's not work-stealing, with performance between `BS::thread_pool` and the two work-stealing pools.

On my Mac:
```
| relative |               ms/op |                op/s |    err% |     total | matrix multiplication 256x256
|---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
|   100.0% |               84.86 |               11.78 |    0.5% |     15.24 | `dp::thread_pool - std::function`
|    69.9% |              121.44 |                8.23 |    4.8% |     21.32 | `BS::thread_pool`
|    71.9% |              118.07 |                8.47 |    5.7% |     21.19 | :wavy_dash: `task_thread_pool` (Unstable with ~16.3 iters. Increase `minEpochIterations` to e.g. 163)
|   117.7% |               72.08 |               13.87 |    3.2% |     12.98 | `riften::Thiefpool`

| relative |               ms/op |                op/s |    err% |     total | matrix multiplication 512x512
|---------:|--------------------:|--------------------:|--------:|----------:|:------------------------------
|   100.0% |               55.32 |               18.08 |    0.4% |      9.92 | `dp::thread_pool - std::function`
|    48.8% |              113.34 |                8.82 |    4.0% |     20.24 | `BS::thread_pool`
|    54.9% |              100.85 |                9.92 |    2.9% |     17.86 | `task_thread_pool`
|   105.6% |               52.37 |               19.09 |    0.4% |      9.44 | `riften::Thiefpool`
```