### PR TITLE
Update cmake version, add new tests, add support for `std::future<void>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 # ---- Project ----
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(ThreadPoolBenchmarks LANGUAGES CXX)
 

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(ThreadPoolDocs)
 

--- a/examples/mandelbrot/CMakeLists.txt
+++ b/examples/mandelbrot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(Mandelbrot LANGUAGES CXX)
 

--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -117,7 +117,12 @@ namespace dp {
             auto task = [func = std::move(f), ... largs = std::move(args),
                          promise = std::move(promise)]() mutable {
                 try {
-                    promise.set_value(func(largs...));
+                    if constexpr (std::is_same_v<ReturnType, void>) {
+                        func(largs...);
+                        promise.set_value();
+                    } else {
+                        promise.set_value(func(largs...));
+                    }
                 } catch (...) {
                     promise.set_exception(std::current_exception());
                 }
@@ -139,7 +144,13 @@ namespace dp {
             auto task = [func = std::move(f), ... largs = std::move(args),
                          promise = shared_promise]() {
                 try {
-                    promise->set_value(func(largs...));
+                    if constexpr (std::is_same_v<ReturnType, void>) {
+                        func(largs...);
+                        promise->set_value();
+                    } else {
+                        promise->set_value(func(largs...));
+                    }
+
                 } catch (...) {
                     promise->set_exception(std::current_exception());
                 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 project(ThreadPoolTests LANGUAGES CXX)
 

--- a/test/source/thread_pool.cpp
+++ b/test/source/thread_pool.cpp
@@ -302,7 +302,8 @@ void recursive_parallel_sort(int* begin, int* end, int split_level, dp::thread_p
 
 TEST_CASE("Recursive parallel sort") {
     std::vector<int> data(10000);
-    std::ranges::iota(data, 0);
+    // std::ranges::iota is a C++23 feature
+    std::iota(data.begin(), data.end(), 0);
     std::ranges::shuffle(data, std::mt19937{std::random_device{}()});
 
     {


### PR DESCRIPTION
## Changes

- Fixed #30 
- Fixed #37 by properly using `std::promise<void>` in the case that the return type is `void` for a given function. This allows you to return `std::future<void>` when calling `dp::thread_pool::enqueue`. 