### PR TITLE
Proposed fix for #40

### DIFF
--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -39,7 +39,7 @@ namespace dp {
             : tasks_(number_of_threads) {
             std::size_t current_id = 0;
             for (std::size_t i = 0; i < number_of_threads; ++i) {
-                priority_queue_.push_back(std::move(i));
+                priority_queue_.push_back(size_t(current_id));
                 try {
                     threads_.emplace_back([&, id = current_id](const std::stop_token &stop_tok) {
                         do {
@@ -82,6 +82,9 @@ namespace dp {
 
                     // remove one item from the tasks
                     tasks_.pop_back();
+
+                    // remove our thread from the priority queue
+                    std::ignore = priority_queue_.pop_back();
                 }
             }
         }

--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -7,7 +7,6 @@
 #include <functional>
 #include <future>
 #include <memory>
-#include <numeric>
 #include <semaphore>
 #include <thread>
 #include <type_traits>

--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -195,7 +195,12 @@ namespace dp {
       private:
         template <typename Function>
         void enqueue_task(Function &&f) {
-            auto i = *(priority_queue_.pop_front());
+            auto i_opt = priority_queue_.copy_front_and_rotate_to_back();
+            if (!i_opt.has_value()) {
+                // would only be a problem if there are zero threads
+                return;
+            }
+            auto i = *(i_opt);
             pending_tasks_.fetch_add(1, std::memory_order_relaxed);
             tasks_[i].tasks.push_back(std::forward<Function>(f));
             tasks_[i].signal.release();

--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -81,6 +81,19 @@ namespace dp {
             data_.push_front(item);
         }
 
+        [[nodiscard]] std::optional<T> copy_front_and_rotate_to_back() {
+            std::scoped_lock lock(mutex_);
+
+            if (data_.empty()) return std::nullopt;
+
+            auto front = data_.front();
+            data_.pop_front();
+
+            data_.push_back(front);
+
+            return front;
+        }
+
       private:
         std::deque<T> data_{};
         mutable Lock mutex_{};

--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <concepts>
 #include <deque>
 #include <mutex>

--- a/test/source/thread_safe_queue.cpp
+++ b/test/source/thread_safe_queue.cpp
@@ -15,21 +15,21 @@ TEST_CASE("Ensure insert and pop works with thread contention") {
         dp::thread_safe_queue<int> queue;
         std::jthread t1([&queue, &barrier, &p1] {
             barrier.arrive_and_wait();
-            queue.push(1);
+            queue.push_front(1);
             barrier.arrive_and_wait();
-            p1.set_value(queue.pop().value_or(-1));
+            p1.set_value(queue.pop_back().value_or(-1));
         });
         std::jthread t2([&queue, &barrier, &p2] {
             barrier.arrive_and_wait();
-            queue.push(2);
+            queue.push_front(2);
             barrier.arrive_and_wait();
-            p2.set_value(queue.pop().value_or(-1));
+            p2.set_value(queue.pop_back().value_or(-1));
         });
         std::jthread t3([&queue, &barrier, &p3] {
             barrier.arrive_and_wait();
-            queue.push(3);
+            queue.push_front(3);
             barrier.arrive_and_wait();
-            p3.set_value(queue.pop().value_or(-1));
+            p3.set_value(queue.pop_back().value_or(-1));
         });
     }
 


### PR DESCRIPTION
This PR edits thread_safe_queue to have more functionality and serve as a priority queue for the threads. 

At the end of each thread execution, the threads bump themselves up to the top of the priority list for work assignment. 