### PR TITLE
feat: add `clear_tasks()`

### DIFF
--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -241,6 +241,22 @@ namespace dp {
             }
         }
 
+        /**
+         * @brief Makes best-case attempt to clear all tasks from the thread_pool
+         * @details Note that this does not guarantee that all tasks will be cleared, as currently
+         * running tasks could add additional tasks. Also a thread could steal a task from another
+         * in the middle of this.
+         * @return number of tasks cleared
+         */
+        size_t clear_tasks() {
+            size_t removed_task_count{0};
+            for (auto &task_list : tasks_) removed_task_count += task_list.tasks.clear();
+            in_flight_tasks_.fetch_sub(removed_task_count, std::memory_order_release);
+            unassigned_tasks_.fetch_sub(removed_task_count, std::memory_order_release);
+
+            return removed_task_count;
+        }
+
       private:
         template <typename Function>
         void enqueue_task(Function &&f) {

--- a/include/thread_pool/thread_safe_queue.h
+++ b/include/thread_pool/thread_safe_queue.h
@@ -44,6 +44,14 @@ namespace dp {
             return data_.empty();
         }
 
+        size_type clear() {
+            std::scoped_lock lock(mutex_);
+            auto size = data_.size();
+            data_.clear();
+
+            return size;
+        }
+
         [[nodiscard]] std::optional<T> pop_front() {
             std::scoped_lock lock(mutex_);
             if (data_.empty()) return std::nullopt;


### PR DESCRIPTION
@DeveloperPaul123 Firstly, thanks for this nice library. I'm glad that mentioned it on reddit. I was thinking of implementing my own thread pool, but you've definitely done a better job than I could have! 

I think it would be useful to have a function for clearing all the tasks in the thread pool. This could be useful when, for example, one loads the thread pool with a list of tasks but then needs to clear them if an error/exception is thrown somewhere.

Note that this not fool-proof, for example a running task could add other tasks to the pool. Or alternatively, during the `for` loop, one thread (which just had it's task list cleared) could steal a thread from another task. But I didn't see a way of getting around these edge cases without adding another mutex

Of course, this is just one possible way of doing this. Please feel to do with the PR as you wish :-).

