### PR TITLE
Bugfix: wait_for_tasks should handle spurious wakeups

### DIFF
--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -235,7 +235,8 @@ namespace dp {
          * @details This function will block until all tasks have been completed.
          */
         void wait_for_tasks() {
-            if (in_flight_tasks_.load(std::memory_order_acquire) > 0) {
+            // must be a while loop to ignore spurious wake-ups
+            while (in_flight_tasks_.load(std::memory_order_acquire) > 0) {
                 // wait for all tasks to finish
                 threads_complete_signal_.wait(false);
             }


### PR DESCRIPTION
atomic waits are subject to spurious wakeups.

This PR ensures the logic in `wait_for_tasks` truly waits for the `threads_complete_signal_` to be `false`.