### PR TITLE
include from same dir

### DIFF
--- a/include/thread_pool/thread_pool.h
+++ b/include/thread_pool/thread_pool.h
@@ -15,7 +15,7 @@
 #    endif
 #endif
 
-#include "thread_pool/thread_safe_queue.h"
+#include "thread_safe_queue.h"
 
 namespace dp {
     namespace details {


### PR DESCRIPTION
`thread_safe_queue.h` is in the same directory as `thread_pool.h`.

The original path prefix made `#include "..."` perform worse, because the first attempt (same dir) would always fail, and it requires user to have the parent dir of `thread_pool` in the header search path.